### PR TITLE
Remove schedule from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,8 +39,5 @@
       ]
     }
   ],
-  "pinDigest": true,
-  "schedule": [
-    "after 6am on thursday"
-  ]
+  "pinDigest": true
 }


### PR DESCRIPTION
In SIG Dev at Giant Swarm we recently decided to change our best practice and let Renovate bot create PRs as soon as an update is available. I suggest to align this repo with those best practices, as long as there isn't any special reason to maintain a separate way.