### PR TITLE
Delete CircleCI annotation from catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,7 +9,6 @@ metadata:
     backstage.io/techdocs-ref: url:https://github.com/[[repo-owner]]/[[project-name]]/tree/main
     giantswarm.io/deployment-names: [[project-name]],[[project-name]]-app
     github.com/project-slug: [[repo-owner]]/[[project-name]]
-    circleci.com/project-slug: github/giantswarm/[[project-name]]
 spec:
   type: service
   lifecycle: experimental


### PR DESCRIPTION
Delete CircleCI annotation from catalog-info.yaml since CircleCI is not used for this project.