### PR TITLE
Let nancy only check dependencies used in current project

### DIFF
--- a/.github/workflows/validate-test.yaml
+++ b/.github/workflows/validate-test.yaml
@@ -38,8 +38,8 @@ jobs:
         with:
           go-version: '1.20.x'
       - name: Write GoList for Nancy
-        run: go list -json -m all > go.list
+        run: go list -json -deps ./... > go.list
       - name: Run Nancy
-        uses: sonatype-nexus-community/nancy-github-action@main
+        uses: sonatype-nexus-community/nancy-github-action@aae196481b961d446f4bff9012e4e3b63d7921a4 # v1.0.2
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
The flag `-m all` leads to listing all known Go modules. If the Go environment is shared with other projects, e. g. through a cache, this can lead to false positives being reported for modules that are not in use in this project.