### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,6 +8,7 @@ metadata:
     backstage.io/source-location: url:https://github.com/[[repo-owner]]/[[project-name]]
     backstage.io/techdocs-ref: url:https://github.com/[[repo-owner]]/[[project-name]]/tree/main
     giantswarm.io/deployment-names: [[project-name]],[[project-name]]-app
+    giantswarm.io/ingress-host: "[[project-name]].demotech-rds.awsprod.gigantic.io"
     giantswarm.io/grafana-dashboard: "/d/cdyhcdr5hge0wa/demotech-web-application-vitals"
     github.com/project-slug: [[repo-owner]]/[[project-name]]
 spec:


### PR DESCRIPTION
Add `giantswarm.io/ingress-host` annotation to catalog-info.yaml.

Relates to https://github.com/giantswarm/backstage/pull/484