### PR TITLE
chore(renovate): migrate to renovate-presets default.json5

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,8 @@
   // This configuration extends the following presets. See
   // https://docs.renovatebot.com/key-concepts/presets/ for more details.
   "extends": [
-    "config:recommended",
+    "github>giantswarm/renovate-presets:default.json5",
+    "github>giantswarm/renovate-presets:lang-go.json5",
   ],
 
   // Labels to add to all PRs


### PR DESCRIPTION
Replaces `config:recommended` with `github>giantswarm/renovate-presets:default.json5`.

Adds `github>giantswarm/renovate-presets:lang-go.json5` (Go service template).

Updated in-place on the existing `renovate.json5` file.

Kept (repo-specific):
- `addLabels`, `automergeType`, `dependencyDashboardOSVVulnerabilitySummary`, `major.dependencyDashboardApproval`, `osvVulnerabilityAlerts`, `packageRules`, `pinDigests`